### PR TITLE
Support not clearing counters when reporting

### DIFF
--- a/graphite.go
+++ b/graphite.go
@@ -23,7 +23,7 @@ type GraphiteConfig struct {
 	Prefix        string           // Prefix to be prepended to metric names
 	Percentiles   []float64        // Percentiles to export from timers and histograms
 
-	PreviousCounterValues map[string]int64 // Map of previous values.  When only send the difference between this and the previous value
+	PreviousCounterValues map[string]int64 // Map of previous values.  Only send the difference between this and the current value, and then update this.
 }
 
 // Graphite is a blocking exporter function which reports metrics in r

--- a/graphite.go
+++ b/graphite.go
@@ -22,6 +22,8 @@ type GraphiteConfig struct {
 	DurationUnit  time.Duration    // Time conversion unit for durations
 	Prefix        string           // Prefix to be prepended to metric names
 	Percentiles   []float64        // Percentiles to export from timers and histograms
+
+	PreviousCounterValues map[string]int64 // Map of previous values.  When only send the difference between this and the previous value
 }
 
 // Graphite is a blocking exporter function which reports metrics in r
@@ -71,8 +73,15 @@ func graphite(c *GraphiteConfig) error {
 	c.Registry.Each(func(name string, i interface{}) {
 		switch metric := i.(type) {
 		case metrics.Counter:
-			ctr := metric.Clear()
-			_, err = fmt.Fprintf(w, "%s.%s.count %d %d\n", c.Prefix, name, ctr.Count(), now)
+			var value int64
+			if c.PreviousCounterValues != nil {
+				current := metric.Snapshot().Count()
+				value = current - c.PreviousCounterValues[name]
+				c.PreviousCounterValues[name] = value
+			} else {
+				value = metric.Clear().Count()
+			}
+			_, err = fmt.Fprintf(w, "%s.%s.count %d %d\n", c.Prefix, name, value, now)
 		case metrics.GaugeCounter:
 			_, err = fmt.Fprintf(w, "%s.%s.value %d %d\n", c.Prefix, name, metric.Count(), now)
 		case metrics.Gauge:

--- a/graphite_test.go
+++ b/graphite_test.go
@@ -177,7 +177,7 @@ func TestWritesWithPreviousCounterValues(t *testing.T) {
 	}
 
 	// Does not reset the counter
-	if ctr.Count() != 2 {
-		t.Fatalf("expected counter to still be %d but got: %d", 2, ctr.Count())
+	if expected, found := int64(2), ctr.Count(); found != expected {
+		t.Fatalf("expected counter to still be %d but got: %d", expected, found)
 	}
 }


### PR DESCRIPTION
This will allow other reporters to report counters accurately when running at the same time.  It's a little hacky (since it adds state to the config object) but it will allow us to do this with minimal changes. By default -- if the map to store previous values is not provided -- the behavior is unchanged from before.

Note that this doesn't solve the same issue for Timers and Histograms, just Counter.